### PR TITLE
add drill fields with all dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Recent and upcoming changes to dbt2looker
 
+## 0.11.7 (Not released to pypy)
+
+### Added
+
+- view level drill fields including all dimensions and dimension groups
+
 ## 0.11.6 (Not released to pypy)
 
 ### Fixed

--- a/dbt2looker/generator.py
+++ b/dbt2looker/generator.py
@@ -383,7 +383,7 @@ def lookml_measures_from_model(model: models.DbtModel):
 
 def lookml_measure(measure_name: str, column: models.DbtModelColumn, measure: models.Dbt2LookerMeasure, model: models.DbtModel):
     measure_description = measure.description or column.description or f'{measure.type.value.capitalize()} of {column.name}'
-    
+
     m = {
         'name': measure_name,
         'type': measure.type.value,
@@ -404,17 +404,40 @@ def lookml_measure(measure_name: str, column: models.DbtModelColumn, measure: mo
         m['hidden'] = measure.hidden.value
     return m
 
+def lookml_set_from_field_list(set_name, fields):
+    # spaces and linebreaks are added for proper indentation in the view.lkml file
+    fields_string = '\n      , '.join(fields)
+    return set_name + ' {\n    fields: [\n      '+  fields_string + '\n    ]\n  }'
+
+def lookml_set_of_dimensions(dimensions, dimension_groups):
+    dimension_group_fields = [
+        dg['name'] + '_' + dg['timeframes'][0]
+        for dg in dimension_groups
+    ]
+    dimension_fields = [
+        d['name']
+        for d in dimensions
+    ]
+    return dimension_group_fields + dimension_fields
+
 
 def lookml_view_from_dbt_model(model: models.DbtModel, adapter_type: models.SupportedDbtAdapters):
     view_name = model.config.meta.view_name or model.name
-    
+
+    dimensions = lookml_dimensions_from_model(model, adapter_type)
+    dimension_groups = lookml_dimension_groups_from_model(model, adapter_type)
+    detail_fields = lookml_set_of_dimensions(dimensions, dimension_groups)
+    set = lookml_set_from_field_list('details', detail_fields)
+
     lookml = {
         'view': {
             'name': view_name,
             'sql_table_name': model.relation_name,
-            'dimension_groups': lookml_dimension_groups_from_model(model, adapter_type),
-            'dimensions': lookml_dimensions_from_model(model, adapter_type),
+            'drill_fields': '[details*]',
+            'dimension_groups': dimension_groups,
+            'dimensions': dimensions,
             'measures': lookml_measures_from_model(model),
+            'set': set
         }
     }
     logging.debug(
@@ -443,7 +466,7 @@ def lookml_model_from_dbt_model(model: models.DbtModel, connection_name: str):
         lookml['explore']['label'] = model.config.meta.label
     if model.config.meta.view_label:
         lookml['explore']['view_label'] = model.config.meta.view_label
-        
+
     # An explore description will start indented at 2 spaces, so subsequent
     # lines should start indented at 2 + 2 spaces.
     if model.description:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt2looker"
-version = "0.11.6"
+version = "0.11.7"
 description = "Generate lookml view files from dbt models"
 authors = ["oliverlaslett <oliver@gethubble.io>", "chaimturkel <cyturel@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Motivation: https://sunbasket.slack.com/archives/C03HXLE9G7L/p1701206872139169

Instead of adding configuration support, I opted for adding drill fields by default with all dimensions and lowest granularity field of dimension groups as that covers all known use cases and were significantly easier to add and use. (no need to change dbt side and no need to maintain a drill fields set if a new dimension is added or removed)

If needed, it can still be customized later.

Generated drill fields already added to looker repo and tested there: [Looker PR](https://github.com/SunBasket/ds-looker-main/pull/58)