### PR TITLE
Do not add `sql` parameter to count measures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Recent and upcoming changes to dbt2looker
 
+## 0.11.11 (Not released to pypy)
+
+### Fixed
+- do not add 'sql' key to measure configuration if type is 'count', see https://cloud.google.com/looker/docs/reference/param-measure-types#count
+
 ## 0.11.10 (Not released to pypy)
 
 ### Fixed

--- a/dbt2looker/generator.py
+++ b/dbt2looker/generator.py
@@ -392,12 +392,15 @@ def lookml_measures_from_model(model: models.DbtModel):
 def lookml_measure(measure_name: str, column: models.DbtModelColumn, measure: models.Dbt2LookerMeasure, model: models.DbtModel):
     measure_description = measure.description or column.description or f'{measure.type.value.capitalize()} of {column.name}'
 
+    _type = measure.type.value
+
     m = {
         'name': measure_name,
-        'type': measure.type.value,
-        'sql': measure.sql or f'${{TABLE}}.{column.name}',
+        'type': _type,
         'description': indent_multiline_description(measure_description),
     }
+    if _type.lower() != 'count':
+        m['sql'] = measure.sql or f'${{TABLE}}.{column.name}'
     if measure.filters:
         m['filters'] = lookml_measure_filters(measure, model)
     if measure.value_format_name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt2looker"
-version = "0.11.9"
+version = "0.11.11"
 description = "Generate lookml view files from dbt models"
 authors = ["oliverlaslett <oliver@gethubble.io>", "chaimturkel <cyturel@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
From Looker docs:

"type: count measures perform table counts that are based on the table's primary
key, so type: count measures don't support the sql parameter."

This PR fixes `generator.py` accordingly.
