### PR TITLE
Add 'group_item_label' optional dimension parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Recent and upcoming changes to dbt2looker
 
+## 0.11.12 (Not released to pypy)
+
+### Added
+- `group_item_label` optional dimension parameter
+
 ## 0.11.11 (Not released to pypy)
 
 ### Fixed

--- a/dbt2looker/generator.py
+++ b/dbt2looker/generator.py
@@ -320,6 +320,11 @@ def get_optional_dimension_fields_dict(props, looker_type):
             {'required_access_grants': props.required_access_grants}
             if (props.required_access_grants)
             else {}
+        ),
+        **(
+            {'group_item_label': props.group_item_label}
+            if (props.group_item_label)
+            else {}
         )
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt2looker"
-version = "0.11.11"
+version = "0.11.12"
 description = "Generate lookml view files from dbt models"
 authors = ["oliverlaslett <oliver@gethubble.io>", "chaimturkel <cyturel@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
This parameter is useful if want to override each of the grouped fields belonging to the same
group. One can add a custom label to a given timeframe in a set of timeframes, for example.
See https://cloud.google.com/looker/docs/reference/param-field-group-item-label. 